### PR TITLE
Trivial tweak to "use" namespace

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,7 +28,7 @@ There is also a [Notificato for Symfony2 bundle](https://github.com/wrep/notific
 // This imports the Composer autoloader
 require_once('vendor/autoload.php');
 
-use \Wrep\Notificato\Notificato;
+use Wrep\Notificato\Notificato;
 
 class GettingStarted
 {


### PR DESCRIPTION
I see people using leading slashes in the global namespace, and as such lots of new developers end up thinking you need to do it. You don't, so its best not to suggest you do.
