### PR TITLE
Reconnect after writing, the connection may have been dropped. Remove usleep that slows down the bulk send.

### DIFF
--- a/src/Wrep/Notificato/Apns/Gateway.php
+++ b/src/Wrep/Notificato/Apns/Gateway.php
@@ -105,6 +105,10 @@ class Gateway extends SslSocket
 
 			// Send the message and check if all the bytes are written
 			$bytesSend = (int)fwrite($this->getConnection(), $binaryMessage);
+
+            // If the connection has been dropped, reconnect to APNS
+            $this->reconnectIfDropped();
+
 			if (strlen($binaryMessage) !== $bytesSend)
 			{
 				// Something did go wrong while sending this message, retry
@@ -121,9 +125,6 @@ class Gateway extends SslSocket
 			{
 				// Mark the message as send without errors
 				$messageEnvelope->setStatus(MessageEnvelope::STATUS_NOERRORS);
-
-				// Take a nap to give PHP some time to relax after sending data over the socket
-				usleep(self::SEND_INTERVAL);
 
 				// Check for errors
 				$this->checkForErrorResponse();

--- a/src/Wrep/Notificato/Apns/Gateway.php
+++ b/src/Wrep/Notificato/Apns/Gateway.php
@@ -170,6 +170,8 @@ class Gateway extends SslSocket
 	 */
 	private function checkForErrorResponse()
 	{
+        $this->reconnectIfDropped();
+
 		// Check if there is something to read from the socket
 		$errorResponse = fread($this->getConnection(), self::ERROR_RESPONSE_SIZE);
 		if (false !== $errorResponse && self::ERROR_RESPONSE_SIZE === strlen($errorResponse))

--- a/src/Wrep/Notificato/Apns/Gateway.php
+++ b/src/Wrep/Notificato/Apns/Gateway.php
@@ -104,10 +104,9 @@ class Gateway extends SslSocket
 			$binaryMessage = $messageEnvelope->getBinaryMessage();
 
 			// Send the message and check if all the bytes are written
-			$bytesSend = (int)fwrite($this->getConnection(), $binaryMessage);
-
             // If the connection has been dropped, reconnect to APNS
             $this->reconnectIfDropped();
+			$bytesSend = (int)fwrite($this->getConnection(), $binaryMessage);
 
 			if (strlen($binaryMessage) !== $bytesSend)
 			{

--- a/src/Wrep/Notificato/Apns/SslSocket.php
+++ b/src/Wrep/Notificato/Apns/SslSocket.php
@@ -139,6 +139,10 @@ abstract class SslSocket implements LoggerAwareInterface
         if (feof($this->getConnection()) === true) {
             $this->disconnect();
             $this->connect();
+
+            return true;
         }
+
+        return false;
     }
 }

--- a/src/Wrep/Notificato/Apns/SslSocket.php
+++ b/src/Wrep/Notificato/Apns/SslSocket.php
@@ -130,4 +130,15 @@ abstract class SslSocket implements LoggerAwareInterface
 
 		$this->connection = null;
 	}
+
+    /**
+     * Reconnect if the connection has been dropped by APNS
+     */
+    protected function reconnectIfDropped()
+    {
+        if (feof($this->getConnection()) === true) {
+            $this->disconnect();
+            $this->connect();
+        }
+    }
 }


### PR DESCRIPTION
Sometime when using the Sandbox mode and invalid UDID, the connection simply drops.

We then get this error :

Warning: fwrite(): SSL: Broken pipe