### PR TITLE
Remove JSON_FORCE_OBJECT flag from json_encode()

### DIFF
--- a/src/Wrep/Notificato/Apns/Message.php
+++ b/src/Wrep/Notificato/Apns/Message.php
@@ -216,7 +216,7 @@ class Message implements \Serializable
 		}
 
 		// Encode as JSON object
-		$json = json_encode($message, JSON_FORCE_OBJECT);
+		$json = json_encode($message);
 		if (false == $json) {
 			throw new \RuntimeException('Failed to convert APNS\Message to JSON, are all strings UTF-8?', json_last_error());
 		}


### PR DESCRIPTION
Fixes the problem with "loc-args" field - it should be a JSON array, not an object:
```json
{"aps":{"alert":{"loc-key":"UnderAttack","loc-args":["Name"]}}}
```
insted of 
```json
{"aps":{"alert":{"loc-key":"UnderAttack","loc-args":{"0":"Name"}}}}
```