### PR TITLE
Remove check on device token length

### DIFF
--- a/src/Wrep/Notificato/Apns/Feedback/Tuple.php
+++ b/src/Wrep/Notificato/Apns/Feedback/Tuple.php
@@ -40,11 +40,6 @@ class Tuple
 			throw new \InvalidArgumentException('Invalid device token given, no hexadecimal: ' . $deviceToken);
 		}
 
-		// Check if the length of the devicetoken is correct
-		if (64 != strlen($deviceToken)) {
-			throw new \InvalidArgumentException('Invalid device token given, incorrect length: ' . $deviceToken . ' (' . strlen($deviceToken) . ')');
-		}
-
 		// Save the data
 		$this->invalidatedAt = new \DateTime('@' . (int)$invalidatedAtTimestamp);
 		$this->deviceToken = $deviceToken;

--- a/src/Wrep/Notificato/Apns/Message.php
+++ b/src/Wrep/Notificato/Apns/Message.php
@@ -294,11 +294,6 @@ class Message implements \Serializable
 			throw new \InvalidArgumentException('Invalid device token given, no hexadecimal: ' . $deviceToken);
 		}
 
-		// Check if the length of the devicetoken is correct
-		if (64 != strlen($deviceToken)) {
-			throw new \InvalidArgumentException('Invalid device token given, incorrect length: ' . $deviceToken . ' (' . strlen($deviceToken) . ')');
-		}
-
 		// Set the devicetoken
 		$this->deviceToken = $deviceToken;
 	}


### PR DESCRIPTION

In the documentation of APNS it says: 
```
IMPORTANT
APNs device tokens are of variable length. Do not hard-code their size.
```
So we should not check on the length of this token, as this can go wrong. The documentation of APNS:
https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html#//apple_ref/doc/uid/TP40008194-CH8-SW14
